### PR TITLE
Fix pyglet vertex list creation

### DIFF
--- a/examples/obj_viewer.py
+++ b/examples/obj_viewer.py
@@ -7,11 +7,22 @@ from src.model_loader import load_obj
 
 
 def create_vertex_list(model):
+    """Create a vertex list for the given model.
+
+    Some versions of ``pyglet`` removed ``vertex_list_indexed`` from the
+    :mod:`pyglet.graphics` module.  To remain compatible across releases we
+    create an indexed vertex list via a ``Batch``.
+    """
+
     vertices = [coord for vertex in model.vertices for coord in vertex]
     indices = [index - 1 for face in model.faces for index in face]
-    return pyglet.graphics.vertex_list_indexed(
-        len(model.vertices), indices, ("v3f/static", vertices)
+
+    batch = pyglet.graphics.Batch()
+    vertex_list = batch.add_indexed(
+        len(model.vertices), GL_TRIANGLES, None, indices, ("v3f/static", vertices)
     )
+
+    return vertex_list
 
 
 def main(path: str):


### PR DESCRIPTION
## Summary
- make the obj viewer compatible with pyglet versions where `vertex_list_indexed` is unavailable by using a Batch

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685157d19fb0832f8b379c323bdfe50a